### PR TITLE
Fix wild card prompt

### DIFF
--- a/src/projectone/UnoGame.java
+++ b/src/projectone/UnoGame.java
@@ -101,12 +101,13 @@ public class UnoGame {
                 continue;
             }
             pile.addCard(firstCard);
-            firstCard.applyEffect(this);
             if (firstCard.getValue() == Value.WILD) {
                 Player firstPlayer = players.get(0);
                 Color chosen = firstPlayer.chooseWildColor(this);
                 setActiveWildColor(chosen);
                 System.out.println(firstPlayer.getName() + " chose starting color: " + chosen);
+            } else {
+                firstCard.applyEffect(this);
             }
             break;
         }


### PR DESCRIPTION
## Summary
- fix duplicate prompt when the opening card is Wild

## Testing
- `javac -d build/classes src/projectone/*.java`
- `javac -cp lib/junit-jupiter-api-5.3.1.jar:lib/junit-platform-console-standalone-1.13.0-M3.jar:build/classes -d build/test-classes test/projectone/*.java`
- `java -jar lib/junit-platform-console-standalone-1.13.0-M3.jar -cp build/classes:build/test-classes --scan-classpath`
